### PR TITLE
Ensure DCR's SLF4J log lines are printed to console

### DIFF
--- a/docker-testing/build.gradle
+++ b/docker-testing/build.gradle
@@ -17,4 +17,5 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.9'
 }

--- a/docker-testing/src/test/resources/logback-test.xml
+++ b/docker-testing/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Before:

<img width="811" alt="screen shot 2017-01-24 at 11 22 57" src="https://cloud.githubusercontent.com/assets/3473798/22262905/87263134-e227-11e6-92eb-6ec1aca9bac4.png">

After:

<img width="818" alt="screen shot 2017-01-24 at 11 20 21" src="https://cloud.githubusercontent.com/assets/3473798/22262914/8c0926fc-e227-11e6-9d0b-0daec0a8fad0.png">
